### PR TITLE
ci: Add Python 3.12 image support

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.12"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -26,5 +31,7 @@ jobs:
         with:
           file: Dockerfile.base
           push: true
-          tags: quara/blez-base:3.10
+          tags: quara/blez-base:${{ matrix.python-version }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}

--- a/.github/workflows/build-blez-image.yml
+++ b/.github/workflows/build-blez-image.yml
@@ -12,7 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version:
+        python-version:
+          - "3.10"
+          - "3.12"
+        bluez-version:
           - "5.66"
           - "5.85"
     steps:
@@ -31,7 +34,8 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: quara/blez:3.10_${{ matrix.version }}
+          tags: quara/blez:${{ matrix.python-version }}_${{ matrix.bluez-version }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           build-args: |
-            BLUEZ_VERSION=${{ matrix.version }}
+            PYTHON_VERSION=${{ matrix.python-version }}
+            BLUEZ_VERSION=${{ matrix.bluez-version }}

--- a/.github/workflows/build-bluez.yml
+++ b/.github/workflows/build-bluez.yml
@@ -18,6 +18,8 @@ jobs:
         version:
           - "3.10_5.66"
           - "3.10_5.85"
+          - "3.12_5.66"
+          - "3.12_5.85"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -27,8 +29,9 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: Build
         run: |
+          PYTHON_VERSION=$(echo "${{ matrix.version }}" | cut -d'_' -f1)
           BLUEZ_VERSION=$(echo "${{ matrix.version }}" | cut -d'_' -f2)
-          ./scripts/cp-build.sh ${{ matrix.platform }} $BLUEZ_VERSION
+          ./scripts/cp-build.sh ${{ matrix.platform }} $PYTHON_VERSION $BLUEZ_VERSION
       - name: Set artifact name
         id: artifact
         run: echo "name=dist-$(echo '${{ matrix.platform }}' | tr '/' '-')-${{ matrix.version }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-cp-image.yml
+++ b/.github/workflows/build-cp-image.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.12"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -26,5 +31,7 @@ jobs:
         with:
           file: Dockerfile.build
           push: true
-          tags: quara/blez-build:3.10
+          tags: quara/blez-build:${{ matrix.python-version }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM quara/blez-base:3.10
+ARG PYTHON_VERSION=3.12
+FROM quara/blez-base:${PYTHON_VERSION}
 
 COPY scripts /opt/blez-scripts
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -7,7 +7,7 @@ RUN apt-get update \
     ca-certificates \
     curl \
     dbus \
-    libglib2.0-0 \
+    libglib2.0-0t64 \
     supervisor \
     && rm -rf \
     /var/lib/apt/lists/* \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,21 +1,22 @@
-FROM python:3.10-slim
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim
 
 # Install runtime dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        dbus \
-        libglib2.0-0 \
-        supervisor \
+    ca-certificates \
+    curl \
+    dbus \
+    libglib2.0-0 \
+    supervisor \
     && rm -rf \
-        /var/lib/apt/lists/* \
-        /var/cache/apt/archives \
+    /var/lib/apt/lists/* \
+    /var/cache/apt/archives \
     && groupadd bluetooth
 
 # Create directories
 RUN mkdir -p \
-        /etc/bluetooth \
-        /etc/dbus-1/system.d \
-        /etc/supervisor \
-        /etc/supervisor.d
+    /etc/bluetooth \
+    /etc/dbus-1/system.d \
+    /etc/supervisor \
+    /etc/supervisor.d

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,19 +1,20 @@
-FROM python:3.10-slim
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        automake \
-        ca-certificates \
-        gcc \
-        git \
-        libdbus-1-dev \
-        libglib2.0-dev \
-        libical-dev \
-        libreadline-dev \
-        libtool \
-        libudev-dev \
-        make \
-        udev \
+    automake \
+    ca-certificates \
+    gcc \
+    git \
+    libdbus-1-dev \
+    libglib2.0-dev \
+    libical-dev \
+    libreadline-dev \
+    libtool \
+    libudev-dev \
+    make \
+    udev \
     && rm -rf \
-        /var/lib/apt/lists/* \
-        /var/cache/apt/archives
+    /var/lib/apt/lists/* \
+    /var/cache/apt/archives

--- a/README.md
+++ b/README.md
@@ -1,5 +1,31 @@
 ## Usage
 
+### Building Docker Images
+
+All Dockerfiles support a `PYTHON_VERSION` build arg (defaults to `3.12`).
+
+```bash
+# Build base image (Python 3.12, default)
+docker build -f Dockerfile.base -t quara/blez-base:3.12 .
+
+# Build base image (Python 3.10)
+docker build -f Dockerfile.base --build-arg PYTHON_VERSION=3.10 -t quara/blez-base:3.10 .
+
+# Build build image (Python 3.12, default)
+docker build -f Dockerfile.build -t quara/blez-build:3.12 .
+
+# Build build image (Python 3.10)
+docker build -f Dockerfile.build --build-arg PYTHON_VERSION=3.10 -t quara/blez-build:3.10 .
+
+# Build final image (Python 3.12, default)
+docker build -t quara/blez:3.12 .
+
+# Build final image (Python 3.10)
+docker build --build-arg PYTHON_VERSION=3.10 -t quara/blez:3.10 .
+```
+
+### Building BlueZ
+
 - Without docker:
 
 ```bash

--- a/scripts/cp-build.sh
+++ b/scripts/cp-build.sh
@@ -2,19 +2,20 @@
 
 set -euo pipefail
 
-BUILD_IMAGE="quara/blez-build:latest"
-
 ROOT_DIR=$(dirname $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ))
 
 function build {
+    PYTHON_VERSION="$1"
+    BUILD_IMAGE="quara/blez-build:${PYTHON_VERSION}"
     OUTPUT_DIR=$(mktemp -d)
-    docker run -i --platform="$PLATFORM" -v "$ROOT_DIR:/build" -v "$OUTPUT_DIR:/dist" -e OUTPUT_DIR=/dist --workdir /build "$BUILD_IMAGE" scripts/build.sh $@
+    docker run -i --platform="$PLATFORM" -v "$ROOT_DIR:/build" -v "$OUTPUT_DIR:/dist" -e OUTPUT_DIR=/dist --workdir /build "$BUILD_IMAGE" scripts/build.sh ${@:2}
     mv "$OUTPUT_DIR" "$ROOT_DIR/dist/"
 }
 
 function main {
     export PLATFORM="$1"
-    build ${@:2}
+    PYTHON_VERSION="$2"
+    build "$PYTHON_VERSION" ${@:3}
     unset PLATFORM
 }
 


### PR DESCRIPTION
## Add Python 3.12 image support

### Summary

Adds Python 3.12 as a supported base image alongside the existing Python 3.10, parameterizing the Python version across all Dockerfiles and CI workflows.

### Changes

**Dockerfiles** — All three Dockerfiles ([Dockerfile](http://_vscodecontentref_/0), [Dockerfile.base](http://_vscodecontentref_/1), [Dockerfile.build](http://_vscodecontentref_/2)) now accept a `PYTHON_VERSION` build arg (defaults to `3.12`) instead of hardcoding `python:3.10-slim`.

**CI Workflows:**

- **[build-base-image.yml](http://_vscodecontentref_/3)** — Added `python-version` matrix (`3.10`, `3.12`). Passes `PYTHON_VERSION` build-arg and tags images as `quara/blez-base:<python-version>`.
- **[build-cp-image.yml](http://_vscodecontentref_/4)** — Added `python-version` matrix (`3.10`, `3.12`). Passes `PYTHON_VERSION` build-arg and tags images as `quara/blez-build:<python-version>`.
- **[build-blez-image.yml](http://_vscodecontentref_/5)** — Split single `version` matrix into `python-version` × `bluez-version` matrix. Tags images as `quara/blez:<python-version>_<bluez-version>`. Passes both `PYTHON_VERSION` and `BLUEZ_VERSION` build-args.
- **[build-bluez.yml](http://_vscodecontentref_/6)** — Added `3.12_5.66` and `3.12_5.85` to the version matrix. Now parses both `PYTHON_VERSION` and `BLUEZ_VERSION` from the composite matrix value and passes both to [cp-build.sh](http://_vscodecontentref_/7).

**Scripts:**

- **[cp-build.sh](http://_vscodecontentref_/8)** — Updated calling convention from `$PLATFORM $BLUEZ_VERSION...` to `$PLATFORM $PYTHON_VERSION $BLUEZ_VERSION...`. Uses `quara/blez-build:<python-version>` instead of the non-existent `:latest` tag.

**Docs** — Updated [README.md](http://_vscodecontentref_/9) with Docker build examples for both Python versions.

### Breaking Changes

- [cp-build.sh](http://_vscodecontentref_/10) now requires a Python version as the second argument:
  ```bash
  # Before
  ./scripts/cp-build.sh linux/amd64 5.66
  # After
  ./scripts/cp-build.sh linux/amd64 3.12 5.66
  ```

### Image Matrix

| Image | Tags |
|-------|------|
| `quara/blez-base` | `3.10`, `3.12` |
| `quara/blez-build` | `3.10`, `3.12` |
| `quara/blez` | `3.10_5.66`, `3.10_5.85`, `3.12_5.66`, `3.12_5.85` |